### PR TITLE
[Feature]/#8 클럽 조회 & 상세 조회 & 핀 상태 변경 api를 구현합니다

### DIFF
--- a/src/main/java/com/holix/holix_server/club/controller/ClubController.java
+++ b/src/main/java/com/holix/holix_server/club/controller/ClubController.java
@@ -2,14 +2,14 @@ package com.holix.holix_server.club.controller;
 
 import com.holix.holix_server.club.dto.request.ChattingCreateRequestDTO;
 import com.holix.holix_server.club.dto.response.ChattingListResponseDTO;
-import com.holix.holix_server.club.dto.response.ChattingResponseDTO;
+import com.holix.holix_server.club.dto.response.ClubDetailResponseDTO;
+import com.holix.holix_server.club.dto.response.ClubListResponseDTO;
+import com.holix.holix_server.club.dto.response.ClubPinResponseDTO;
 import com.holix.holix_server.club.service.ClubService;
 import com.holix.holix_server.global.code.CommonSuccessCode;
 import com.holix.holix_server.global.response.HolixResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
-
-import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,4 +33,25 @@ public class ClubController {
         clubService.createChatting(clubId, chattingCreateRequestDTO);
         return HolixResponse.success(CommonSuccessCode.OK);
     }
+
+    @GetMapping
+    public HolixResponse<ClubListResponseDTO> getClubList(
+    ) {
+        return HolixResponse.success(CommonSuccessCode.OK, clubService.getClubList());
+    }
+
+    @GetMapping("/{clubId}")
+    public HolixResponse<ClubDetailResponseDTO> getClubDetail(
+            @PathVariable final Long clubId
+    ) {
+        return HolixResponse.success(CommonSuccessCode.OK, clubService.getClubDetail(clubId));
+    }
+
+    @PatchMapping("/{clubId}")
+    public HolixResponse<ClubPinResponseDTO> patchPinStatus(
+            @PathVariable final Long clubId
+    ) {
+        return HolixResponse.success(CommonSuccessCode.OK, clubService.patchPinStatus(clubId));
+    }
+
 }

--- a/src/main/java/com/holix/holix_server/club/dto/response/ClubDetailResponseDTO.java
+++ b/src/main/java/com/holix/holix_server/club/dto/response/ClubDetailResponseDTO.java
@@ -1,0 +1,22 @@
+package com.holix.holix_server.club.dto.response;
+
+import com.holix.holix_server.club.extension.ClubExtension;
+import com.holix.holix_server.club.model.Club;
+
+public record ClubDetailResponseDTO(
+        Long clubId,
+        String title,
+        String url,
+        String participants,
+        String notice
+) {
+    public static ClubDetailResponseDTO from(Club club) {
+        return new ClubDetailResponseDTO(
+                club.getClubId(),
+                club.getClubTitle(),
+                club.getImgUrl(),
+                ClubExtension.formatParticipants(club.getParticipants(), club.getMaxParticipants()),
+                club.getNotice()
+        );
+    }
+}

--- a/src/main/java/com/holix/holix_server/club/dto/response/ClubListResponseDTO.java
+++ b/src/main/java/com/holix/holix_server/club/dto/response/ClubListResponseDTO.java
@@ -1,0 +1,11 @@
+package com.holix.holix_server.club.dto.response;
+
+import java.util.List;
+
+public record ClubListResponseDTO(
+        List<ClubResponseDTO> clubListResponseDTO
+) {
+    public static ClubListResponseDTO from(List<ClubResponseDTO> clubResponseDTOList) {
+        return new ClubListResponseDTO(clubResponseDTOList);
+    }
+}

--- a/src/main/java/com/holix/holix_server/club/dto/response/ClubListResponseDTO.java
+++ b/src/main/java/com/holix/holix_server/club/dto/response/ClubListResponseDTO.java
@@ -3,7 +3,7 @@ package com.holix.holix_server.club.dto.response;
 import java.util.List;
 
 public record ClubListResponseDTO(
-        List<ClubResponseDTO> clubListResponseDTO
+        List<ClubResponseDTO> clubs
 ) {
     public static ClubListResponseDTO from(List<ClubResponseDTO> clubResponseDTOList) {
         return new ClubListResponseDTO(clubResponseDTOList);

--- a/src/main/java/com/holix/holix_server/club/dto/response/ClubPinResponseDTO.java
+++ b/src/main/java/com/holix/holix_server/club/dto/response/ClubPinResponseDTO.java
@@ -1,0 +1,7 @@
+package com.holix.holix_server.club.dto.response;
+
+public record ClubPinResponseDTO(Boolean isPinned) {
+    public static ClubPinResponseDTO from(Boolean isPinned) {
+        return new ClubPinResponseDTO(isPinned);
+    }
+}

--- a/src/main/java/com/holix/holix_server/club/dto/response/ClubResponseDTO.java
+++ b/src/main/java/com/holix/holix_server/club/dto/response/ClubResponseDTO.java
@@ -1,0 +1,22 @@
+package com.holix.holix_server.club.dto.response;
+
+import com.holix.holix_server.club.extension.ClubExtension;
+import com.holix.holix_server.club.model.Club;
+
+public record ClubResponseDTO(
+        Long clubId,
+        String title,
+        Boolean isPinned,
+        String url,
+        String participants
+) {
+    public static ClubResponseDTO from(Club club) {
+        return new ClubResponseDTO(
+                club.getClubId(),
+                club.getClubTitle(),
+                club.getIsPinned(),
+                club.getImgUrl(),
+                ClubExtension.formatParticipants(club.getParticipants(), club.getMaxParticipants())
+        );
+    }
+}

--- a/src/main/java/com/holix/holix_server/club/extension/ClubExtension.java
+++ b/src/main/java/com/holix/holix_server/club/extension/ClubExtension.java
@@ -1,0 +1,8 @@
+package com.holix.holix_server.club.extension;
+
+public class ClubExtension {
+
+    public static String formatParticipants(Integer participants, Integer maxParticipants) {
+        return String.format("%d명 / %d명", participants, maxParticipants);
+    }
+}

--- a/src/main/java/com/holix/holix_server/club/model/Club.java
+++ b/src/main/java/com/holix/holix_server/club/model/Club.java
@@ -46,4 +46,8 @@ public class Club {
         this.participants = participants;
         this.maxParticipants = maxParticipants;
     }
+
+    public void updatePinStatus() {
+        this.isPinned = !isPinned;
+    }
 }

--- a/src/main/java/com/holix/holix_server/club/repository/ClubRepository.java
+++ b/src/main/java/com/holix/holix_server/club/repository/ClubRepository.java
@@ -2,6 +2,11 @@ package com.holix.holix_server.club.repository;
 
 import com.holix.holix_server.club.model.Club;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
+@Repository
 public interface ClubRepository extends JpaRepository<Club, Long> {
+    List<Club> findAllByOrderByIsPinnedDesc();
 }

--- a/src/main/java/com/holix/holix_server/club/service/ClubService.java
+++ b/src/main/java/com/holix/holix_server/club/service/ClubService.java
@@ -2,8 +2,7 @@ package com.holix.holix_server.club.service;
 
 import com.holix.holix_server.club.code.ClubErrorCode;
 import com.holix.holix_server.club.dto.request.ChattingCreateRequestDTO;
-import com.holix.holix_server.club.dto.response.ChattingListResponseDTO;
-import com.holix.holix_server.club.dto.response.ChattingResponseDTO;
+import com.holix.holix_server.club.dto.response.*;
 import com.holix.holix_server.club.model.Chatting;
 import com.holix.holix_server.club.model.ChattingType;
 import com.holix.holix_server.club.model.Club;
@@ -15,6 +14,7 @@ import com.holix.holix_server.user.model.User;
 import com.holix.holix_server.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -58,5 +58,33 @@ public class ClubService {
                 .build();
 
         chattingRepository.save(chatting);
+    }
+
+    public ClubListResponseDTO getClubList() {
+        List<Club> clubList = clubRepository.findAllByOrderByIsPinnedDesc();
+
+        return ClubListResponseDTO.from(
+                clubList.stream()
+                        .map(ClubResponseDTO::from)
+                        .toList()
+        );
+    }
+
+    public ClubDetailResponseDTO getClubDetail(final Long clubId) {
+        Club clubDetail = clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        return ClubDetailResponseDTO.from(clubDetail);
+    }
+
+
+    @Transactional
+    public ClubPinResponseDTO patchPinStatus(final Long clubId) {
+        Club club = clubRepository.findById(clubId)
+                .orElseThrow(() -> new BusinessException(ClubErrorCode.CLUB_NOT_FOUND));
+
+        club.updatePinStatus();
+
+        return ClubPinResponseDTO.from(club.getIsPinned());
     }
 }


### PR DESCRIPTION
<!----[PullRequestType]/#IssueNumber: 작업 내용 -->
<!----ex) [Add]/#1: 이슈 템플릿을 생성합니다 -->

## **🗣️ ISSUE**

- closed #8

## **❗ WORK DESCRIPTION**

- 클럽 리스트 형태로 조회 구현
    - true값을 기준으로 정렬
- 클럽 상세 조회 구현
- 클럽 핀 상태 변경 구현
- 클럽 상세 및 핀 상태 변경 예외처리 (해당 클럽이 없을 경우)

<!---- ## **📸 SCREENSHOT** -->

<!---- <img src="" width="300" /> -->
클럽 조회 | 클럽 상세 조회 | 클럽 핀 상태 변경
  :--: | :--: | :--:
  <img src="https://github.com/user-attachments/assets/ad21e290-95b5-4c2b-a3c8-44dee1f62a82" width="300" /> | <img src="https://github.com/user-attachments/assets/e9b26d78-0814-4eb2-9aa6-805d0e3476d8" width="300" > | <img src="https://github.com/user-attachments/assets/4b89291f-3c13-4660-8bf5-80e99024c344" width="300" >

## **💻 주요 코드**

- 저번에 신청/최대인원수를 "O명 / O명" 의 형태로 통일해서 이를 확장함수로 구현했습니다. 피그마 보니까 Club 도메인에서만 사용하면 될 것 같아서 파일은 Club 하위에 두었습니다 :) 
```
public class ClubExtension {

    public static String formatParticipants(Integer participants, Integer maxParticipants) {
        return String.format("%d명 / %d명", participants, maxParticipants);
    }
}
```

## **📢 TO REVIEWERS**

- 파이륑
